### PR TITLE
Added test prereq HTTP::Request::Common as suggested by CPANTS.

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -2,6 +2,7 @@ requires 'perl', '5.10.1';
 
 on test => sub {
     requires 'Test::More', '>=0.96';
+    requires 'HTTP::Request::Common';
 };
 
 requires 'AnyEvent::HTTP';


### PR DESCRIPTION
Hi @vpeil 

Please review the PR.

https://cpants.cpanauthors.org/release/VPEIL/Plack-Middleware-Matomo-0.01

       test_prereq_matches_use
       List all modules used in the test suite in META.yml test_requires

       Error:

        HTTP::Request::Common

Many Thanks.
Best Regards,
Mohammad S Anwar